### PR TITLE
TPG Threshold By Plane

### DIFF
--- a/apps/wibeth_tpg_algorithms_emulator.cxx
+++ b/apps/wibeth_tpg_algorithms_emulator.cxx
@@ -49,6 +49,16 @@ main(int argc, char** argv)
     int tpg_threshold = 500;
     app.add_option("-t,--tpg-threshold", tpg_threshold, "Value of the TPG threshold. Default value is 500.");
 
+    // <plane>_threshold gets updated to tpg_threshold if still -1 after parsing.
+    int collection_threshold = -1;
+    app.add_option("-Z,--collection", collection_threshold, "Value of the collection TPG threshold. Default value is tpg_threshold.");
+
+    int induction1_threshold = -1;
+    app.add_option("-U,--induction-one", induction1_threshold, "Value of the induction 1 TPG threshold. Default value is tpg_threshold.");
+
+    int induction2_threshold = -1;
+    app.add_option("-V,--induction-two", induction2_threshold, "Value of the induction 2 TPG threshold. Default value is tpg_threshold.");
+
     int core_number = 0;
     app.add_option("-c,--core", core_number, "Set core number of the executing TPG thread. Default value is 0.");
 
@@ -66,6 +76,12 @@ main(int argc, char** argv)
 
     CLI11_PARSE(app, argc, argv);
 
+    // Default the threshold.
+    collection_threshold = collection_threshold == -1 ? tpg_threshold : collection_threshold;
+    induction1_threshold = induction1_threshold == -1 ? tpg_threshold : induction1_threshold;
+    induction2_threshold = induction2_threshold == -1 ? tpg_threshold : induction2_threshold;
+
+
     // =================================================================
     //                       Setup the TPG emulator
     // =================================================================
@@ -81,7 +97,7 @@ main(int argc, char** argv)
       throw tpgtools::InvalidImplementation(ERS_HERE, select_implementation);  
     }
 
-    emulator->set_tpg_threshold(tpg_threshold);
+    emulator->set_tpg_thresholds(collection_threshold, induction1_threshold, induction2_threshold);
     emulator->set_CPU_affinity(core_number);
     emulator->set_num_frames_to_save(num_frames_to_save);
     emulator->initialize();

--- a/apps/wibeth_tpg_validation.cxx
+++ b/apps/wibeth_tpg_validation.cxx
@@ -40,6 +40,15 @@ main(int argc, char** argv)
     int tpg_threshold = 500;
     app.add_option("-t,--tpg-threshold", tpg_threshold, "Value of the TPG threshold. Default value is 500.");
 
+    int collection_threshold = tpg_threshold;
+    app.add_option("-Z,--collection", collection_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+
+    int induction1_threshold = tpg_threshold;
+    app.add_option("-U,--induction-one", induction1_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+
+    int induction2_threshold = tpg_threshold;
+    app.add_option("-V,--induction-two", induction2_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+
     int core_number = 0;
     app.add_option("-c,--core", core_number, "Set core number of the executing TPG thread. Default value is 0.");
 
@@ -85,7 +94,7 @@ main(int argc, char** argv)
       throw tpgtools::InvalidImplementation(ERS_HERE, select_implementation);  
     }
     
-    emulator->set_tpg_threshold(tpg_threshold);
+    emulator->set_tpg_thresholds(collection_threshold, induction1_threshold, induction2_threshold);
     emulator->set_CPU_affinity(core_number);
     emulator->initialize();
 

--- a/apps/wibeth_tpg_workload_emulator.cxx
+++ b/apps/wibeth_tpg_workload_emulator.cxx
@@ -50,6 +50,15 @@ main(int argc, char** argv)
     int tpg_threshold = 500;
     app.add_option("-t,--tpg-threshold", tpg_threshold, "Value of the TPG threshold. Default value is 500.");
 
+    int collection_threshold = tpg_threshold;
+    app.add_option("-Z,--collection", collection_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+
+    int induction1_threshold = tpg_threshold;
+    app.add_option("-U,--induction-one", induction1_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+
+    int induction2_threshold = tpg_threshold;
+    app.add_option("-V,--induction-two", induction2_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+
     int core_number = 0;
     app.add_option("-c,--core", core_number, "Set core number of the executing TPG thread. Default value is 0.");
 
@@ -104,7 +113,7 @@ main(int argc, char** argv)
       throw tpgtools::InvalidImplementation(ERS_HERE, select_implementation);  
     }
     
-    emulator->set_tpg_threshold(tpg_threshold);
+    emulator->set_tpg_thresholds(collection_threshold, induction1_threshold, induction2_threshold);
     emulator->set_CPU_affinity(core_number);
     emulator->initialize();
     emulator->set_out_suffix(out_suffix);

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@ Options:
   -m,--channel-map TEXT       Select a valid channel map: None, VDColdboxChannelMap, ProtoDUNESP1ChannelMap, PD2HDChannelMap, HDColdboxChannelMap, FiftyLChannelMap
   -n,--num-TR-to-read INT     Number of Trigger Records to read. Default: select all TRs.
   -t,--tpg-threshold INT      Value of the TPG threshold. Default value is 500.
+  -Z,--collection INT         Value of the TPG threshold. Default value is tpg_threshold.
+  -U,--induction-one INT      Value of the TPG threshold. Default value is tpg_threshold.
+  -V,--induction-two INT      Value of the TPG threshold. Default value is tpg_threshold.
   -c,--core INT               Set core number of the executing TPG thread. Default value is 0.
   --save-adc-data             Save ADC data (first frame only)
   --save-trigprim             Save trigger primitive data
@@ -32,6 +35,7 @@ Example of usage:
 ```sh
 $ wibeth_tpg_algorithms_emulator -f swtest_run000035_0000_dataflow0_datawriter_0_20231102T083908.hdf5  -a SimpleThreshold -m PD2HDChannelMap -t 500 --save-trigprim --parse_trigger_primitive
 $ wibeth_tpg_algorithms_emulator -f swtest_run000035_0000_dataflow0_datawriter_0_20231102T083908.hdf5  -a AbsRS -m PD2HDChannelMap -t 500 --save-adc-data  -n 5 
+$ wibeth_tpg_algorithms_emulator -f swtest_run000035_0000_dataflow0_datawriter_0_20231102T083908.hdf5  -a AbsRS -m PD2HDChannelMap -t 500 --save-adc-data  -n 5 -Z 200
 ```
 
 
@@ -185,6 +189,9 @@ Options:
   -m,--channel-map TEXT       Select a valid channel map: None, VDColdboxChannelMap, ProtoDUNESP1ChannelMap, PD2HDChannelMap, HDColdboxChannelMap, FiftyLChannelMap
   -d,--duration-test INT      Duration (in seconds) to run the test. Default value is 120.
   -t,--tpg-threshold INT      Value of the TPG threshold. Default value is 500.
+  -Z,--collection INT         Value of the TPG threshold. Default value is tpg_threshold.
+  -U,--induction-one INT      Value of the TPG threshold. Default value is tpg_threshold.
+  -V,--induction-two INT      Value of the TPG threshold. Default value is tpg_threshold.
   -c,--core INT               Set core number of the executing TPG thread. Default value is 0.
   --save-adc-data             Save ADC data (first frame only)
   --save-trigprim             Save trigger primitive data
@@ -196,7 +203,7 @@ Options:
 Example of usage: 
 ```sh
 $ wibeth_tpg_pattern_generator -f /cvmfs/dunedaq.opensciencegrid.org/assets/files/d/d/1/wibeth_output_all_zeros.bin -o . --save-trigprim -w -n 2 -t 64 -i 0 -c 63 -p patt_golden -s __63
-$ tpg_workload_emulator -f patt_golden_chan_0_tick_63_wibeth_output.bin -r false -a SimpleThreshold -i NAIVE  -n 2 -t 499 -m ProtoDUNESP1ChannelMap
+$ wibeth_tpg_workload_emulator -f patt_golden_chan_0_tick_63_wibeth_output.bin -r false -a SimpleThreshold -i NAIVE  -n 2 -t 499 -m ProtoDUNESP1ChannelMap -Z 200
 ```
 
 Please note, when using `wibeth_output_all_zeros.bin` input file from the asset repository, the `-w` option is needed to overwrite the header information. The generated pattern file, `patt_golden_chan_0_tick_63_wibeth_output.bin`, is then used as input to the `tpg_workload_emulator` app.  
@@ -205,7 +212,7 @@ More examples of usage:
 ```sh
 $ wibeth_tpg_workload_emulator -f patt_golden_chan_0_tick_1_wibeth_output.bin -r false -a SimpleThreshold -i NAIVE -n 2 -t 64  --save-trigprim -s __1
 $ wibeth_tpg_workload_emulator -f patt_golden_chan_0_tick_1_wibeth_output.bin -r false -a SimpleThreshold -i AVX -n 2 -t 64  --save-trigprim -s __1
-wibeth_tpg_workload_emulator -f patt_golden_chan_0_tick_63_wibeth_output.bin -r false -m VDColdboxChannelMap --save-trigprim -n 2 -t 64 -c 63 -a AbsRS -i AVX
+$ wibeth_tpg_workload_emulator -f patt_golden_chan_0_tick_63_wibeth_output.bin -r false -m VDColdboxChannelMap --save-trigprim -n 2 -t 64 -c 63 -a AbsRS -i AVX
 ```
 
 ### Running `pytest`

--- a/include/tpgtools/TPGEmulator.hpp
+++ b/include/tpgtools/TPGEmulator.hpp
@@ -58,7 +58,18 @@ public:
     if (!m_select_channel_map.empty()) {
       m_register_channel_map = swtpg_wibeth::get_register_to_offline_channel_map_wibeth(frame, m_channel_map);             
       for (size_t i = 0; i < swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER; ++i) {
-        m_register_channels[i] = m_register_channel_map.channel[i];                
+        auto chan_value = m_register_channel_map.channel[i];
+
+        m_register_channels[i] = chan_value;
+        m_register_memory_factor[i] = m_tpg_rs_memory_factor;
+        m_planes[i] = m_channel_map->get_plane_from_offline_channel(chan_value);
+        if (m_channel_map->get_plane_from_offline_channel(chan_value) == 2) { // Collection
+          m_tpg_threshold[i] = m_collection_threshold;
+        } else if (m_channel_map->get_plane_from_offline_channel(chan_value) == 1) { // Induction 2
+          m_tpg_threshold[i] = m_induction2_threshold;
+        } else { // Must be Induction 1
+          m_tpg_threshold[i] = m_induction1_threshold;
+        }
       }
     } else {
       // If no channel map is not selected use the values from 0 to 63
@@ -69,8 +80,10 @@ public:
   void save_raw_data(swtpg_wibeth::MessageRegisters register_array,
                      uint64_t t0, int channel_number, std::string algo);
 
-  void set_tpg_threshold(int tpg_threshold){
-    m_tpg_threshold = tpg_threshold;
+  void set_tpg_thresholds(int collection_threshold, int induction1_threshold, int induction2_threshold){
+    m_collection_threshold = collection_threshold;
+    m_induction1_threshold = induction1_threshold;
+    m_induction2_threshold = induction2_threshold;
   }
 
   void set_CPU_affinity(int core_number) {
@@ -111,7 +124,13 @@ public:
   dunedaq::trgdataformats::TriggerPrimitive::Algorithm m_tp_algo = dunedaq::trgdataformats::TriggerPrimitive::Algorithm::kUnknown; 
 
 
-  int m_tpg_threshold = 500; //default value 
+  std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER>
+    m_tpg_threshold = {10000}; // Default value.
+  std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER>
+    m_planes; // Default value.
+  int m_collection_threshold = 150;
+  int m_induction1_threshold = 150;
+  int m_induction2_threshold = 150;
   int m_CPU_core = 0;
   int m_num_frames_to_save = 1;
 

--- a/src/TPGEmulator.cpp
+++ b/src/TPGEmulator.cpp
@@ -170,6 +170,7 @@ void tpg_emulator_avx::execute_tpg(const dunedaq::fdreadoutlibs::types::DUNEWIBE
 
   
   if (m_first_hit) {   
+    m_frame_handler.m_tpg_processing_info->setThresholdState(m_tpg_threshold);
     m_frame_handler.m_tpg_processing_info->setState(registers_array, m_register_memory_factor);
     m_first_hit = false;    
     // Save ADC info
@@ -219,7 +220,7 @@ void tpg_emulator_avx::execute_tpg(const dunedaq::fdreadoutlibs::types::DUNEWIBE
     }
 
     // Initialize frame handler
-    m_frame_handler.initialize(m_tpg_threshold, m_tpg_rs_memory_factor, m_tpg_rs_scale_factor, m_tpg_frugal_streaming_accumulator_limit);
+    m_frame_handler.initialize(m_tpg_rs_memory_factor, m_tpg_rs_scale_factor, m_tpg_frugal_streaming_accumulator_limit);
 
 };
 
@@ -294,8 +295,9 @@ void tpg_emulator_naive::execute_tpg(const dunedaq::fdreadoutlibs::types::DUNEWI
 
   
   if (m_first_hit) {   
+    m_frame_handler.m_tpg_processing_info->setThresholdState(m_tpg_threshold);
     m_frame_handler.m_tpg_processing_info->setState(registers_array, m_register_memory_factor);
-    m_first_hit = false;    
+    m_first_hit = false;
     // Save ADC info
     if (m_save_adc_data && m_num_frames_to_save == 1) {
       save_raw_data(registers_array, timestamp, -1, m_select_algorithm);
@@ -341,7 +343,7 @@ void tpg_emulator_naive::initialize()  {
    
   // Initialize frame handler
   // AAA: fix me with proper TPG configuration parameters
-  m_frame_handler.initialize(m_tpg_threshold, m_tpg_rs_memory_factor, m_tpg_rs_scale_factor, m_tpg_frugal_streaming_accumulator_limit);
+  m_frame_handler.initialize(m_tpg_rs_memory_factor, m_tpg_rs_scale_factor, m_tpg_frugal_streaming_accumulator_limit);
 
 
 };


### PR DESCRIPTION
This PR follows the new TPG threshold by plane implementation in [fdreadoutlibs](https://github.com/DUNE-DAQ/fdreadoutlibs/pull/177). Running any of `wibeth_tpg_validation`, `wibeth_tpg_workload_emulator`, or `wibeth_tpg_algorithms_emulator` now include the option to specify the thresholds for each plane. If a plane's threshold is not specified, it defaults to the general TPG threshold value.

Testing was limited with this implementation because the emulators prepare thresholds according to the first WIBEth frame seen. Expanding to use thresholds for all frames still has issues: TPs which do not complete by the end of a WIBEth fragment are left "above threshold" until the next fragment and instead mark the new fragment as having a TP. This frequently resulted in incorrect channels appearing above threshold and confounds the result of the threshold by plane.

The solution for how to process WIBEth frames and emulate effectively seems outside the scope of this PR.