### PR TITLE
Added TPG RS Factors By Plane

### DIFF
--- a/apps/wibeth_tpg_algorithms_emulator.cxx
+++ b/apps/wibeth_tpg_algorithms_emulator.cxx
@@ -49,15 +49,41 @@ main(int argc, char** argv)
     int tpg_threshold = 500;
     app.add_option("-t,--tpg-threshold", tpg_threshold, "Value of the TPG threshold. Default value is 500.");
 
-    // <plane>_threshold gets updated to tpg_threshold if still -1 after parsing.
-    int collection_threshold = -1;
-    app.add_option("-Z,--collection", collection_threshold, "Value of the collection TPG threshold. Default value is tpg_threshold.");
+    // tpg_threshold_plane<n> gets updated to tpg_threshold if still -1 after parsing.
+    int tpg_threshold_plane2 = -1;
+    app.add_option("-Z,--plane-two", tpg_threshold_plane2, "Value of the plane 2 TPG threshold. Default value is tpg_threshold.");
 
-    int induction1_threshold = -1;
-    app.add_option("-U,--induction-one", induction1_threshold, "Value of the induction 1 TPG threshold. Default value is tpg_threshold.");
+    int tpg_threshold_plane1 = -1;
+    app.add_option("-V,--plane-one", tpg_threshold_plane1, "Value of the plane 1 TPG threshold. Default value is tpg_threshold.");
 
-    int induction2_threshold = -1;
-    app.add_option("-V,--induction-two", induction2_threshold, "Value of the induction 2 TPG threshold. Default value is tpg_threshold.");
+    int tpg_threshold_plane0 = -1;
+    app.add_option("-U,--plane-zero", tpg_threshold_plane0, "Value of the plane 0 TPG threshold. Default value is tpg_threshold.");
+
+    // tpg_rs_memory_factor_plane<n> gets updated to tpg_rs_memory_factor_default if still -1 after parsing.
+    float tpg_rs_memory_factor = 0.8;
+    app.add_option("--rs-memory", tpg_rs_memory_factor, "Value of the general tpg_rs_memory_factor.");
+
+    float tpg_rs_memory_factor_plane2 = -1;
+    app.add_option("--rs-memory-two", tpg_rs_memory_factor_plane2, "Value of the plane 2 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.");
+
+    float tpg_rs_memory_factor_plane1 = -1;
+    app.add_option("--rs-memory-one", tpg_rs_memory_factor_plane1, "Value of the plane 1 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.");
+
+    float tpg_rs_memory_factor_plane0 = -1;
+    app.add_option("--rs-memory-zero", tpg_rs_memory_factor_plane0, "Value of the plane 0 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.");
+
+    // tpg_rs_scale_factor_plane<n> gets updated to tpg_rs_scale_factor_default if still -1 after parsing.
+    int tpg_rs_scale_factor = 2;
+    app.add_option("--rs-scale", tpg_rs_scale_factor, "Value of the general tpg_rs_scale_factor.");
+
+    int tpg_rs_scale_factor_plane2 = -1;
+    app.add_option("--rs-scale-two", tpg_rs_scale_factor_plane2, "Value of the plane 2 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.");
+
+    int tpg_rs_scale_factor_plane1 = -1;
+    app.add_option("--rs-scale-one", tpg_rs_scale_factor_plane1, "Value of the plane 1 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.");
+
+    int tpg_rs_scale_factor_plane0 = -1;
+    app.add_option("--rs-scale-zero", tpg_rs_scale_factor_plane0, "Value of the plane 0 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.");
 
     int core_number = 0;
     app.add_option("-c,--core", core_number, "Set core number of the executing TPG thread. Default value is 0.");
@@ -77,9 +103,19 @@ main(int argc, char** argv)
     CLI11_PARSE(app, argc, argv);
 
     // Default the threshold.
-    collection_threshold = collection_threshold == -1 ? tpg_threshold : collection_threshold;
-    induction1_threshold = induction1_threshold == -1 ? tpg_threshold : induction1_threshold;
-    induction2_threshold = induction2_threshold == -1 ? tpg_threshold : induction2_threshold;
+    tpg_threshold_plane2 = tpg_threshold_plane2 == -1 ? tpg_threshold : tpg_threshold_plane2;
+    tpg_threshold_plane1 = tpg_threshold_plane1 == -1 ? tpg_threshold : tpg_threshold_plane1;
+    tpg_threshold_plane0 = tpg_threshold_plane0 == -1 ? tpg_threshold : tpg_threshold_plane0;
+
+    // Default the memory factor.
+    tpg_rs_memory_factor_plane2 = tpg_rs_memory_factor_plane2 == -1 ? tpg_rs_memory_factor : tpg_rs_memory_factor_plane2;
+    tpg_rs_memory_factor_plane1 = tpg_rs_memory_factor_plane1 == -1 ? tpg_rs_memory_factor : tpg_rs_memory_factor_plane1;
+    tpg_rs_memory_factor_plane0 = tpg_rs_memory_factor_plane0 == -1 ? tpg_rs_memory_factor : tpg_rs_memory_factor_plane0;
+
+    // Default the scale factor.
+    tpg_rs_scale_factor_plane2 = tpg_rs_scale_factor_plane2 == -1 ? tpg_rs_scale_factor : tpg_rs_scale_factor_plane2;
+    tpg_rs_scale_factor_plane1 = tpg_rs_scale_factor_plane1 == -1 ? tpg_rs_scale_factor : tpg_rs_scale_factor_plane1;
+    tpg_rs_scale_factor_plane0 = tpg_rs_scale_factor_plane0 == -1 ? tpg_rs_scale_factor : tpg_rs_scale_factor_plane0;
 
 
     // =================================================================
@@ -97,7 +133,9 @@ main(int argc, char** argv)
       throw tpgtools::InvalidImplementation(ERS_HERE, select_implementation);  
     }
 
-    emulator->set_tpg_thresholds(collection_threshold, induction1_threshold, induction2_threshold);
+    emulator->set_tpg_thresholds(tpg_threshold_plane2, tpg_threshold_plane1, tpg_threshold_plane0);
+    emulator->set_rs_factors(tpg_rs_memory_factor_plane2, tpg_rs_memory_factor_plane1, tpg_rs_memory_factor_plane0,
+                             tpg_rs_scale_factor_plane2, tpg_rs_scale_factor_plane1, tpg_rs_scale_factor_plane0);
     emulator->set_CPU_affinity(core_number);
     emulator->set_num_frames_to_save(num_frames_to_save);
     emulator->initialize();

--- a/apps/wibeth_tpg_validation.cxx
+++ b/apps/wibeth_tpg_validation.cxx
@@ -40,14 +40,40 @@ main(int argc, char** argv)
     int tpg_threshold = 500;
     app.add_option("-t,--tpg-threshold", tpg_threshold, "Value of the TPG threshold. Default value is 500.");
 
-    int collection_threshold = tpg_threshold;
-    app.add_option("-Z,--collection", collection_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+    int tpg_threshold_plane2 = tpg_threshold;
+    app.add_option("-Z,--plane-two", tpg_threshold_plane2, "Value of the TPG threshold. Default value is tpg_threshold.");
 
-    int induction1_threshold = tpg_threshold;
-    app.add_option("-U,--induction-one", induction1_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+    int tpg_threshold_plane1 = tpg_threshold;
+    app.add_option("-V,--plane-one", tpg_threshold_plane1, "Value of the TPG threshold. Default value is tpg_threshold.");
 
-    int induction2_threshold = tpg_threshold;
-    app.add_option("-V,--induction-two", induction2_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+    int tpg_threshold_plane0 = tpg_threshold;
+    app.add_option("-U,--plane-zero", tpg_threshold_plane0, "Value of the TPG threshold. Default value is tpg_threshold.");
+
+    // tpg_rs_memory_factor_plane<n> gets updated to tpg_rs_memory_factor_default if still -1 after parsing.
+    float tpg_rs_memory_factor = 0.8;
+    app.add_option("--rs-memory", tpg_rs_memory_factor, "Value of the general tpg_rs_memory_factor.");
+
+    float tpg_rs_memory_factor_plane2 = tpg_rs_memory_factor;
+    app.add_option("--rs-memory-two", tpg_rs_memory_factor_plane2, "Value of the plane 2 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.");
+
+    float tpg_rs_memory_factor_plane1 = tpg_rs_memory_factor;
+    app.add_option("--rs-memory-one", tpg_rs_memory_factor_plane1, "Value of the plane 1 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.");
+
+    float tpg_rs_memory_factor_plane0 = tpg_rs_memory_factor;
+    app.add_option("--rs-memory-zero", tpg_rs_memory_factor_plane0, "Value of the plane 0 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.");
+
+    // tpg_rs_scale_factor_plane<n> gets updated to tpg_rs_scale_factor_default if still -1 after parsing.
+    int tpg_rs_scale_factor = 2;
+    app.add_option("--rs-scale", tpg_rs_scale_factor, "Value of the general tpg_rs_scale_factor.");
+
+    int tpg_rs_scale_factor_plane2 = tpg_rs_scale_factor;
+    app.add_option("--rs-scale-two", tpg_rs_scale_factor_plane2, "Value of the plane 2 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.");
+
+    int tpg_rs_scale_factor_plane1 = tpg_rs_scale_factor;
+    app.add_option("--rs-scale-one", tpg_rs_scale_factor_plane1, "Value of the plane 1 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.");
+
+    int tpg_rs_scale_factor_plane0 = tpg_rs_scale_factor;
+    app.add_option("--rs-scale-zero", tpg_rs_scale_factor_plane0, "Value of the plane 0 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.");
 
     int core_number = 0;
     app.add_option("-c,--core", core_number, "Set core number of the executing TPG thread. Default value is 0.");
@@ -94,7 +120,9 @@ main(int argc, char** argv)
       throw tpgtools::InvalidImplementation(ERS_HERE, select_implementation);  
     }
     
-    emulator->set_tpg_thresholds(collection_threshold, induction1_threshold, induction2_threshold);
+    emulator->set_tpg_thresholds(tpg_threshold_plane2, tpg_threshold_plane1, tpg_threshold_plane0);
+    emulator->set_rs_factors(tpg_rs_memory_factor_plane2, tpg_rs_memory_factor_plane1, tpg_rs_memory_factor_plane0,
+                             tpg_rs_scale_factor_plane2, tpg_rs_scale_factor_plane1, tpg_rs_scale_factor_plane0);
     emulator->set_CPU_affinity(core_number);
     emulator->initialize();
 

--- a/apps/wibeth_tpg_workload_emulator.cxx
+++ b/apps/wibeth_tpg_workload_emulator.cxx
@@ -50,14 +50,40 @@ main(int argc, char** argv)
     int tpg_threshold = 500;
     app.add_option("-t,--tpg-threshold", tpg_threshold, "Value of the TPG threshold. Default value is 500.");
 
-    int collection_threshold = tpg_threshold;
-    app.add_option("-Z,--collection", collection_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+    int tpg_threshold_plane2 = tpg_threshold;
+    app.add_option("-Z,--plane-two", tpg_threshold_plane2, "Value of the TPG threshold. Default value is tpg_threshold.");
 
-    int induction1_threshold = tpg_threshold;
-    app.add_option("-U,--induction-one", induction1_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+    int tpg_threshold_plane1 = tpg_threshold;
+    app.add_option("-V,--plane-one", tpg_threshold_plane1, "Value of the TPG threshold. Default value is tpg_threshold.");
 
-    int induction2_threshold = tpg_threshold;
-    app.add_option("-V,--induction-two", induction2_threshold, "Value of the TPG threshold. Default value is tpg_threshold.");
+    int tpg_threshold_plane0 = tpg_threshold;
+    app.add_option("-U,--plane-zero", tpg_threshold_plane0, "Value of the TPG threshold. Default value is tpg_threshold.");
+
+    // tpg_rs_memory_factor_plane<n> gets updated to tpg_rs_memory_factor_default if still -1 after parsing.
+    float tpg_rs_memory_factor = 0.8;
+    app.add_option("--rs-memory", tpg_rs_memory_factor, "Value of the general tpg_rs_memory_factor.");
+
+    float tpg_rs_memory_factor_plane2 = tpg_rs_memory_factor;
+    app.add_option("--rs-memory-two", tpg_rs_memory_factor_plane2, "Value of the plane 2 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.");
+
+    float tpg_rs_memory_factor_plane1 = tpg_rs_memory_factor;
+    app.add_option("--rs-memory-one", tpg_rs_memory_factor_plane1, "Value of the plane 1 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.");
+
+    float tpg_rs_memory_factor_plane0 = tpg_rs_memory_factor;
+    app.add_option("--rs-memory-zero", tpg_rs_memory_factor_plane0, "Value of the plane 0 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.");
+
+    // tpg_rs_scale_factor_plane<n> gets updated to tpg_rs_scale_factor_default if still -1 after parsing.
+    int tpg_rs_scale_factor = 2;
+    app.add_option("--rs-scale", tpg_rs_scale_factor, "Value of the general tpg_rs_scale_factor.");
+
+    int tpg_rs_scale_factor_plane2 = tpg_rs_scale_factor;
+    app.add_option("--rs-scale-two", tpg_rs_scale_factor_plane2, "Value of the plane 2 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.");
+
+    int tpg_rs_scale_factor_plane1 = tpg_rs_scale_factor;
+    app.add_option("--rs-scale-one", tpg_rs_scale_factor_plane1, "Value of the plane 1 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.");
+
+    int tpg_rs_scale_factor_plane0 = tpg_rs_scale_factor;
+    app.add_option("--rs-scale-zero", tpg_rs_scale_factor_plane0, "Value of the plane 0 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.");
 
     int core_number = 0;
     app.add_option("-c,--core", core_number, "Set core number of the executing TPG thread. Default value is 0.");
@@ -113,7 +139,9 @@ main(int argc, char** argv)
       throw tpgtools::InvalidImplementation(ERS_HERE, select_implementation);  
     }
     
-    emulator->set_tpg_thresholds(collection_threshold, induction1_threshold, induction2_threshold);
+    emulator->set_tpg_thresholds(tpg_threshold_plane2, tpg_threshold_plane0, tpg_threshold_plane1);
+    emulator->set_rs_factors(tpg_rs_memory_factor_plane2, tpg_rs_memory_factor_plane1, tpg_rs_memory_factor_plane0,
+                             tpg_rs_scale_factor_plane2, tpg_rs_scale_factor_plane1, tpg_rs_scale_factor_plane0);
     emulator->set_CPU_affinity(core_number);
     emulator->initialize();
     emulator->set_out_suffix(out_suffix);

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
 # tpgtools 
-Here is a short summary of the applications and scripts available in `tpgtools` 
+Here is a short summary of the applications and scripts available in `tpgtools`
 
 ## Emulator
 
-`wibeth_tpg_algorithms_emulator` is an emulator application for TPG algorithms. It takes as input a Trigger Record file (`*.hdf5` file) and it will execute the selected TPG algorithm on the Trigger Record data. The application is single threaded, pinned to core 0. The core number is configurable.   
+`wibeth_tpg_algorithms_emulator` is an emulator application for TPG algorithms. It takes as input a Trigger Record file (`*.hdf5` file) and it will execute the selected TPG algorithm on the Trigger Record data. The application is single threaded, pinned to core 0. The core number is configurable.
 
 To use the tool use the following:
 ```sh
-$ wibeth_tpg_algorithms_emulator --help 
+$ wibeth_tpg_algorithms_emulator --help
 TPG algorithms emulator using input from Trigger Record files
 Usage: wibeth_tpg_algorithms_emulator [OPTIONS]
 
@@ -19,9 +19,17 @@ Options:
   -m,--channel-map TEXT       Select a valid channel map: None, VDColdboxChannelMap, ProtoDUNESP1ChannelMap, PD2HDChannelMap, HDColdboxChannelMap, FiftyLChannelMap
   -n,--num-TR-to-read INT     Number of Trigger Records to read. Default: select all TRs.
   -t,--tpg-threshold INT      Value of the TPG threshold. Default value is 500.
-  -Z,--plane-two INT          Value of the TPG threshold. Default value is tpg_threshold.
-  -V,--plane-one INT          Value of the TPG threshold. Default value is tpg_threshold.
-  -U,--plane-zero INT         Value of the TPG threshold. Default value is tpg_threshold.
+  -Z,--plane-two INT          Value of the plane 2 TPG threshold. Default value is tpg_threshold.
+  -V,--plane-one INT          Value of the plane 1 TPG threshold. Default value is tpg_threshold.
+  -U,--plane-zero INT         Value of the plane 0 TPG threshold. Default value is tpg_threshold.
+  --rs-memory FLOAT           Value of the general tpg_rs_memory_factor.
+  --rs-memory-two FLOAT       Value of the plane 2 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.
+  --rs-memory-one FLOAT       Value of the plane 1 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.
+  --rs-memory-zero FLOAT      Value of the plane 0 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.
+  --rs-scale INT              Value of the general tpg_rs_scale_factor.
+  --rs-scale-two INT          Value of the plane 2 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.
+  --rs-scale-one INT          Value of the plane 1 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.
+  --rs-scale-zero INT         Value of the plane 0 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.
   -c,--core INT               Set core number of the executing TPG thread. Default value is 0.
   --save-adc-data             Save ADC data (first frame only)
   --save-trigprim             Save trigger primitive data
@@ -29,13 +37,14 @@ Options:
   -s,--num-frames-to-save INT Set the number of frames of ADC data from a TR to save: -1 (all) or 1. Default: 1 (first frame only).
 ```
 
-The command line option `save_adc_data` allows to save the raw ADC values in a txt file after the 14-bit to 16-bit expansion. The command line option `save_trigprim`  allows to save the in a file the Trigger Primitive object information in a txt file. 
+The command line option `save_adc_data` allows to save the raw ADC values in a txt file after the 14-bit to 16-bit expansion. The command line option `save_trigprim`  allows to save the in a file the Trigger Primitive object information in a txt file.
 
-Example of usage: 
+Example of usage:
 ```sh
 $ wibeth_tpg_algorithms_emulator -f swtest_run000035_0000_dataflow0_datawriter_0_20231102T083908.hdf5  -a SimpleThreshold -m PD2HDChannelMap -t 500 --save-trigprim --parse_trigger_primitive
 $ wibeth_tpg_algorithms_emulator -f swtest_run000035_0000_dataflow0_datawriter_0_20231102T083908.hdf5  -a AbsRS -m PD2HDChannelMap -t 500 --save-adc-data  -n 5 
 $ wibeth_tpg_algorithms_emulator -f swtest_run000035_0000_dataflow0_datawriter_0_20231102T083908.hdf5  -a AbsRS -m PD2HDChannelMap -t 500 --save-adc-data  -n 5 -Z 200
+$ wibeth_tpg_algorithms_emulator -f swtest_run000035_0000_dataflow0_datawriter_0_20231102T083908.hdf5  -a AbsRS -m PD2HDChannelMap -t 500 --save-adc-data  -n 5 -Z 200 --rs-memory 0.9 --rs-memory-two 0 --rs-scale-two 1
 ```
 
 
@@ -192,6 +201,14 @@ Options:
   -Z,--plane-two INT          Value of the TPG threshold. Default value is tpg_threshold.
   -V,--plane-one INT          Value of the TPG threshold. Default value is tpg_threshold.
   -U,--plane-zero INT         Value of the TPG threshold. Default value is tpg_threshold.
+  --rs-memory FLOAT           Value of the general tpg_rs_memory_factor.
+  --rs-memory-two FLOAT       Value of the plane 2 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.
+  --rs-memory-one FLOAT       Value of the plane 1 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.
+  --rs-memory-zero FLOAT      Value of the plane 0 TPG rs_memory_factor. Default value is tpg_rs_memory_factor.
+  --rs-scale INT              Value of the general tpg_rs_scale_factor.
+  --rs-scale-two INT          Value of the plane 2 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.
+  --rs-scale-one INT          Value of the plane 1 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.
+  --rs-scale-zero INT         Value of the plane 0 TPG rs_scale_factor. Default value is tpg_rs_scale_factor.
   -c,--core INT               Set core number of the executing TPG thread. Default value is 0.
   --save-adc-data             Save ADC data (first frame only)
   --save-trigprim             Save trigger primitive data
@@ -204,6 +221,7 @@ Example of usage:
 ```sh
 $ wibeth_tpg_pattern_generator -f /cvmfs/dunedaq.opensciencegrid.org/assets/files/d/d/1/wibeth_output_all_zeros.bin -o . --save-trigprim -w -n 2 -t 64 -i 0 -c 63 -p patt_golden -s __63
 $ wibeth_tpg_workload_emulator -f patt_golden_chan_0_tick_63_wibeth_output.bin -r false -a SimpleThreshold -i NAIVE  -n 2 -t 499 -m ProtoDUNESP1ChannelMap -Z 200
+$ wibeth_tpg_workload_emulator -f patt_golden_chan_0_tick_63_wibeth_output.bin -r false -a AbsRS -i NAIVE  -n 2 -t 499 -m ProtoDUNESP1ChannelMap -Z 200 -U 100 --rs-memory-two 0 --rs-scale-two 1
 ```
 
 Please note, when using `wibeth_output_all_zeros.bin` input file from the asset repository, the `-w` option is needed to overwrite the header information. The generated pattern file, `patt_golden_chan_0_tick_63_wibeth_output.bin`, is then used as input to the `tpg_workload_emulator` app.  

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,9 +19,9 @@ Options:
   -m,--channel-map TEXT       Select a valid channel map: None, VDColdboxChannelMap, ProtoDUNESP1ChannelMap, PD2HDChannelMap, HDColdboxChannelMap, FiftyLChannelMap
   -n,--num-TR-to-read INT     Number of Trigger Records to read. Default: select all TRs.
   -t,--tpg-threshold INT      Value of the TPG threshold. Default value is 500.
-  -Z,--collection INT         Value of the TPG threshold. Default value is tpg_threshold.
-  -U,--induction-one INT      Value of the TPG threshold. Default value is tpg_threshold.
-  -V,--induction-two INT      Value of the TPG threshold. Default value is tpg_threshold.
+  -Z,--plane-two INT          Value of the TPG threshold. Default value is tpg_threshold.
+  -V,--plane-one INT          Value of the TPG threshold. Default value is tpg_threshold.
+  -U,--plane-zero INT         Value of the TPG threshold. Default value is tpg_threshold.
   -c,--core INT               Set core number of the executing TPG thread. Default value is 0.
   --save-adc-data             Save ADC data (first frame only)
   --save-trigprim             Save trigger primitive data
@@ -189,9 +189,9 @@ Options:
   -m,--channel-map TEXT       Select a valid channel map: None, VDColdboxChannelMap, ProtoDUNESP1ChannelMap, PD2HDChannelMap, HDColdboxChannelMap, FiftyLChannelMap
   -d,--duration-test INT      Duration (in seconds) to run the test. Default value is 120.
   -t,--tpg-threshold INT      Value of the TPG threshold. Default value is 500.
-  -Z,--collection INT         Value of the TPG threshold. Default value is tpg_threshold.
-  -U,--induction-one INT      Value of the TPG threshold. Default value is tpg_threshold.
-  -V,--induction-two INT      Value of the TPG threshold. Default value is tpg_threshold.
+  -Z,--plane-two INT          Value of the TPG threshold. Default value is tpg_threshold.
+  -V,--plane-one INT          Value of the TPG threshold. Default value is tpg_threshold.
+  -U,--plane-zero INT         Value of the TPG threshold. Default value is tpg_threshold.
   -c,--core INT               Set core number of the executing TPG thread. Default value is 0.
   --save-adc-data             Save ADC data (first frame only)
   --save-trigprim             Save trigger primitive data

--- a/include/tpgtools/TPGEmulator.hpp
+++ b/include/tpgtools/TPGEmulator.hpp
@@ -61,14 +61,19 @@ public:
         auto chan_value = m_register_channel_map.channel[i];
 
         m_register_channels[i] = chan_value;
-        m_register_memory_factor[i] = m_tpg_rs_memory_factor;
         m_planes[i] = m_channel_map->get_plane_from_offline_channel(chan_value);
-        if (m_channel_map->get_plane_from_offline_channel(chan_value) == 2) { // Collection
-          m_tpg_threshold[i] = m_collection_threshold;
-        } else if (m_channel_map->get_plane_from_offline_channel(chan_value) == 1) { // Induction 2
-          m_tpg_threshold[i] = m_induction2_threshold;
-        } else { // Must be Induction 1
-          m_tpg_threshold[i] = m_induction1_threshold;
+        if (m_channel_map->get_plane_from_offline_channel(chan_value) == 2) {
+          m_tpg_threshold[i] = m_tpg_threshold_plane2;
+          m_register_memory_factor[i] = m_tpg_rs_memory_factor_plane2;
+          m_register_scale_factor[i] = m_tpg_rs_scale_factor_plane2;
+        } else if (m_channel_map->get_plane_from_offline_channel(chan_value) == 1) {
+          m_tpg_threshold[i] = m_tpg_threshold_plane1;
+          m_register_memory_factor[i] = m_tpg_rs_memory_factor_plane1;
+          m_register_scale_factor[i] = m_tpg_rs_scale_factor_plane1;
+        } else {
+          m_tpg_threshold[i] = m_tpg_threshold_plane0;
+          m_register_memory_factor[i] = m_tpg_rs_memory_factor_plane0;
+          m_register_scale_factor[i] = m_tpg_rs_scale_factor_plane0;
         }
       }
     } else {
@@ -80,10 +85,22 @@ public:
   void save_raw_data(swtpg_wibeth::MessageRegisters register_array,
                      uint64_t t0, int channel_number, std::string algo);
 
-  void set_tpg_thresholds(int collection_threshold, int induction1_threshold, int induction2_threshold){
-    m_collection_threshold = collection_threshold;
-    m_induction1_threshold = induction1_threshold;
-    m_induction2_threshold = induction2_threshold;
+  void set_tpg_thresholds(int tpg_threshold_plane2, int tpg_threshold_plane1, int tpg_threshold_plane0){
+    m_tpg_threshold_plane2 = tpg_threshold_plane2;
+    m_tpg_threshold_plane1 = tpg_threshold_plane1;
+    m_tpg_threshold_plane0 = tpg_threshold_plane0;
+  }
+
+  void set_rs_factors(float tpg_rs_memory_factor_plane2, float tpg_rs_memory_factor_plane1, float tpg_rs_memory_factor_plane0,
+                      float tpg_rs_scale_factor_plane2, float tpg_rs_scale_factor_plane1, float tpg_rs_scale_factor_plane0)
+  {
+    m_tpg_rs_memory_factor_plane2 = (int)(10*tpg_rs_memory_factor_plane2);
+    m_tpg_rs_memory_factor_plane1 = (int)(10*tpg_rs_memory_factor_plane1);
+    m_tpg_rs_memory_factor_plane0 = (int)(10*tpg_rs_memory_factor_plane0);
+
+    m_tpg_rs_scale_factor_plane2 = 10/tpg_rs_scale_factor_plane2;
+    m_tpg_rs_scale_factor_plane1 = 10/tpg_rs_scale_factor_plane1;
+    m_tpg_rs_scale_factor_plane0 = 10/tpg_rs_scale_factor_plane0;
   }
 
   void set_CPU_affinity(int core_number) {
@@ -128,14 +145,20 @@ public:
     m_tpg_threshold = {10000}; // Default value.
   std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER>
     m_planes; // Default value.
-  int m_collection_threshold = 150;
-  int m_induction1_threshold = 150;
-  int m_induction2_threshold = 150;
+  int m_tpg_threshold_plane2 = 150;
+  int m_tpg_threshold_plane1 = 150;
+  int m_tpg_threshold_plane0 = 150;
   int m_CPU_core = 0;
   int m_num_frames_to_save = 1;
 
   uint16_t m_tpg_rs_memory_factor = 8;
+  uint16_t m_tpg_rs_memory_factor_plane2 = 8;
+  uint16_t m_tpg_rs_memory_factor_plane1 = 8;
+  uint16_t m_tpg_rs_memory_factor_plane0 = 8;
   uint16_t m_tpg_rs_scale_factor = 5;
+  uint16_t m_tpg_rs_scale_factor_plane2 = 5;
+  uint16_t m_tpg_rs_scale_factor_plane1 = 5;
+  uint16_t m_tpg_rs_scale_factor_plane0 = 5;
   int16_t m_tpg_frugal_streaming_accumulator_limit = 10;  
 
   // Frame Handler 
@@ -155,6 +178,7 @@ public:
   // AAA: silver bullet to be able to use SimpleThreshold on collection and RS on induction planes
   // By default set all the values to the selected memory factor 
   std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER> m_register_memory_factor = {0};
+  std::array<uint16_t, swtpg_wibeth::NUM_REGISTERS_PER_FRAME * swtpg_wibeth::SAMPLES_PER_REGISTER> m_register_scale_factor = {0};
 
   // TR info for validation purposes
   int m_register_TR_record_idx = -1;

--- a/src/TPGEmulator.cpp
+++ b/src/TPGEmulator.cpp
@@ -171,7 +171,8 @@ void tpg_emulator_avx::execute_tpg(const dunedaq::fdreadoutlibs::types::DUNEWIBE
   
   if (m_first_hit) {   
     m_frame_handler.m_tpg_processing_info->setThresholdState(m_tpg_threshold);
-    m_frame_handler.m_tpg_processing_info->setState(registers_array, m_register_memory_factor);
+    m_frame_handler.m_tpg_processing_info->setRunningSumState(m_register_memory_factor, m_register_scale_factor);
+    m_frame_handler.m_tpg_processing_info->setState(registers_array);
     m_first_hit = false;    
     // Save ADC info
     if (m_save_adc_data && m_num_frames_to_save == 1) {
@@ -220,7 +221,7 @@ void tpg_emulator_avx::execute_tpg(const dunedaq::fdreadoutlibs::types::DUNEWIBE
     }
 
     // Initialize frame handler
-    m_frame_handler.initialize(m_tpg_rs_memory_factor, m_tpg_rs_scale_factor, m_tpg_frugal_streaming_accumulator_limit);
+    m_frame_handler.initialize(m_tpg_frugal_streaming_accumulator_limit);
 
 };
 
@@ -296,7 +297,8 @@ void tpg_emulator_naive::execute_tpg(const dunedaq::fdreadoutlibs::types::DUNEWI
   
   if (m_first_hit) {   
     m_frame_handler.m_tpg_processing_info->setThresholdState(m_tpg_threshold);
-    m_frame_handler.m_tpg_processing_info->setState(registers_array, m_register_memory_factor);
+    m_frame_handler.m_tpg_processing_info->setRunningSumState(m_register_memory_factor, m_register_scale_factor);
+    m_frame_handler.m_tpg_processing_info->setState(registers_array);
     m_first_hit = false;
     // Save ADC info
     if (m_save_adc_data && m_num_frames_to_save == 1) {
@@ -343,7 +345,7 @@ void tpg_emulator_naive::initialize()  {
    
   // Initialize frame handler
   // AAA: fix me with proper TPG configuration parameters
-  m_frame_handler.initialize(m_tpg_rs_memory_factor, m_tpg_rs_scale_factor, m_tpg_frugal_streaming_accumulator_limit);
+  m_frame_handler.initialize(m_tpg_frugal_streaming_accumulator_limit);
 
 
 };


### PR DESCRIPTION
Running sum memory and scale factors are now configurable by plane. The functionality changes are in [fdreadoutlibs](https://github.com/DUNE-DAQ/fdreadoutlibs/pull/178). This PR covers the required changes in emulation.

Testing involved running `wibeth_tpg_algorithm_emulator` on an HDF5 file with various configs and _loosely_ checking the quality of the resulting TPs. There is a problem with how emulation currently operates, and some TPs starting in one plane may appear in another plane. This added difficulty in thoroughly checking the quality and consistency of the AVX and NAIVE algorithms with these new changes, so most of the `fdreadoutlibs` testing was done online.

There will be a future PR that addresses the shortcomings of the TPG emulators.