### PR TITLE
update make_map to make_tpc_map

### DIFF
--- a/src/TPGEmulator.cpp
+++ b/src/TPGEmulator.cpp
@@ -141,7 +141,7 @@ void tpg_emulator_avx::extract_hits(uint16_t* output_location, uint64_t timestam
     // Initialize the channel map if a valid name has been selected
     if (!m_select_channel_map.empty()) {
       TLOG() << "Using channel map: " << m_select_channel_map;
-      m_channel_map = dunedaq::detchannelmaps::make_map(m_select_channel_map);
+      m_channel_map = dunedaq::detchannelmaps::make_tpc_map(m_select_channel_map);
     }
 
     // Initialize frame handler


### PR DESCRIPTION
Needed by changes here: https://github.com/DUNE-DAQ/detchannelmaps/pull/59

Note: this should only be merged once the fddaq-v5.3.2 patch branches have been merged again to develop. 

ALSO ... I note that this is still asking for readoutlibs (rather than datahandlinglibs) in the CMakeLists.txt file? So I was unable to compile in v5. --> maybe some other work to be done here still.